### PR TITLE
Proposal: Add SIG Security 

### DIFF
--- a/special-interest-groups/security/README.md
+++ b/special-interest-groups/security/README.md
@@ -1,0 +1,25 @@
+
+# SIG Interoperability
+
+## Goals
+
+This group covers horizontal security initiatives for the ICON ecosystem projects, including security audits, vulnerability management, security documentation, and community management on endeavors related to security
+
+## Meetings
+
+{/* TODO: List public meetings here assignees: han-so1omon */}
+
+## Projects
+
+None for this SIG
+
+## Contributing
+
+[CONTRIBUTING.md](../../CONTRIBUTING.md)
+
+## Contact
+
+{/* 
+  TODO: List comms channels here
+  assignees: han-so1omon
+*/}

--- a/special-interest-groups/security/charter.md
+++ b/special-interest-groups/security/charter.md
@@ -1,0 +1,78 @@
+# SIG Interoperability Charter
+
+| Status        | (Proposed)       |
+:-------------- |:---------------------------------------------------- |
+| **PR Link**     | [PR 43](https://github.com/icon-project/community/pull/55)|
+| **Author(s)** | Eric Solomon (eric@icon.foundation) |
+| **Sponsor**   | Eric Solomon (eric@icon.foundation) |
+| **Updated**   | 14 September 2022 |
+
+This charter adheres to the [SIG governance guidelines](/guidelines/governance/sig-governance-guidelines.md).
+
+## Overview
+
+This group covers horizontal security initiatives for the ICON ecosystem projects, including security audits, vulnerability management, security documentation, and community management on endeavors related to security. 
+
+## Scope
+
+### Security Audits
+
+Manage recurring security audits and follow up on issues. Coordinate vendors to perform the audit and publish the findings. Follow up on issues with the affected SIG and help coordinate resolution, which can include:
+
+- Helping to prioritize the fixes, possibly by recruiting from SIG Security (while acknowledging that the ultimate authority in deciding whether and how to fix an issue lies with the responsible SIG).
+- Documenting mitigations, workarounds, or caveats, especially when the responsible SIG decides not to fix a reported issue.
+
+### Vulnerability Management
+
+Work with the ICON Security Response Committee to define the processes for fixing and disclosing vulnerabilities, as outlined in https://github.com/icon-project/. For example:
+
+- When the private fix & release process is invoked
+- How vulnerabilities are rated
+- The scope of the bug bounty
+- Post-announcement follow-ups, such as additional fixes, mitigations, preventions or documentation after a vulnerability is made public
+- Distributor announcement policies, such as timelines, criteria for joining the list, etc
+- How, when and where vulnerabilities are announced
+- Defining the criteria and process for supporting ICON sub-ecosystems, such as the BTP, ICON main network, or ICE/SNOW
+
+### Security Documentation
+
+Author and maintain security documentation, such as hardening guides and security benchmarks. Seek out and coordinate with experts in other SIGs for input on the documentation (i.e. we go to them, they don't need to come to us). In-scope documentation includes:
+
+- Hardening guides and best practices
+- Security benchmarks
+- Improving documentation to address common misunderstandings or questions
+- Threat models
+
+### Community management on endeavors related to security
+
+Provide an entry point to the ICON community for new security-minded contributors and participants, as well as a meeting point to discuss security themes and issues within the ICON ecosystem, including:
+
+- Work with SIG Contributor Experience to curate and staff security discussion channels (e.g. discord channel, mailing list, discourse, stack overflow, etc.).
+- Answer security questions from inexperienced users (that don't know what SIG to go to), and identify common questions or issues as areas for improvement.
+- Provide an "entry point" for new contributors interested in security. Route these new contributors to other SIGs when they have more specific goals (e.g. SIG Interoperability for cross-chain messaging).
+
+### Out of scope
+
+SIG Security does not own any code from the ICON ecosystem projects
+
+Further, SIG Security’s scope does not include:
+
+- Any projects outside of the ICON ecosystem projects
+- Cloud provider-specific or distributor-specific hardening guides
+- Recommendations or endorsements of specific commercial product vendors or cloud providers
+- Private vulnerability response (belongs to the Security Response Committee), including:
+  - Embargoed vulnerability management
+  - Bug bounty submission triage and management
+  - Non-public vulnerability collection, triage, and disclosure
+
+## Governance
+
+This SIG adheres to the [SIG governance guidelines](/guidelines/governance/sig-governance-guidelines.md). Any changes from the guidelines should be noted here.
+
+## Contacts
+
+SIG chair & technical lead: [Eric Solomon](https://github.com/han-so1omon)
+
+## Projects
+
+None defined for this SIG

--- a/special-interest-groups/security/charter.md
+++ b/special-interest-groups/security/charter.md
@@ -2,7 +2,7 @@
 
 | Status        | (Proposed)       |
 :-------------- |:---------------------------------------------------- |
-| **PR Link**     | [PR 43](https://github.com/icon-project/community/pull/55)|
+| **PR Link**   | [PR 43](https://github.com/icon-project/community/pull/55)|
 | **Author(s)** | Eric Solomon (eric@icon.foundation) |
 | **Sponsor**   | Eric Solomon (eric@icon.foundation) |
 | **Updated**   | 14 September 2022 |

--- a/special-interest-groups/security/charter.md
+++ b/special-interest-groups/security/charter.md
@@ -2,7 +2,7 @@
 
 | Status        | (Proposed)       |
 :-------------- |:---------------------------------------------------- |
-| **PR Link**   | [PR 43](https://github.com/icon-project/community/pull/55)|
+| **PR Link**   | [PR 56](https://github.com/icon-project/community/pull/56)|
 | **Author(s)** | Eric Solomon (eric@icon.foundation) |
 | **Sponsor**   | Eric Solomon (eric@icon.foundation) |
 | **Updated**   | 14 September 2022 |


### PR DESCRIPTION
Add charter, explain purpose of SIG

Add readme, explain goals, meeting times, projects, etc for SIG

Establish SIG chair & technical lead as [Eric Solomon](https://github.com/han-so1moon) temporarily as this SIG is established and security-related community members are onboarded